### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ A pre-built [Sketch3](http://bohemiancoding.com/sketch/) file for quickly export
 
 Made with love and care for [EverTrue](https://github.com/evertrue) by Mat Budelman
 
-#Installation
+# Installation
 None. Requires Sketch3 by Bohemian Coding. Buy [Sketch3](http://bohemiancoding.com/sketch/).
 
-#How-to: Three magic steps.
+# How-to: Three magic steps.
 
 1. Download the [zipped Sketch3 file](https://github.com/budelman/ios-launch-screen-template-for-sketch/blob/master/ios8_default-images_template.sketch.zip?raw=true).
 2. Unzip, open the file, and add your artwork to each artboard.
 3. Click the "Export" icon and get back to making cool shit.
 
-##Preview
+## Preview
 
 ===
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
